### PR TITLE
Validate model to be instance of desired class

### DIFF
--- a/lib/dry/initializer/rails.rb
+++ b/lib/dry/initializer/rails.rb
@@ -9,6 +9,10 @@ rails_dispatcher = lambda do |model: nil, find_by: :id, **options|
   klass = model.is_a?(ActiveRecord::Relation) ? model.klass : model
 
   coercer = lambda do |value|
+    if value.is_a?(ActiveRecord::Base) && !value.instance_of?(klass)
+      raise "Value `#{value}` is not instance of `#{klass}`"
+    end
+
     return value if value.nil? || value.is_a?(klass)
     model.find_by! find_by => value
   end


### PR DESCRIPTION
Initializer Rails allows passing any ActiveRecord model, despite the specified class.

I have some doubts that this is the best or "dry" way to handle this case, I just wanted to point out this issue with a possible solution.

---

#### Example
```ruby
class CreateOrder
  extend Dry::Initializer

  param :customer, model: Customer
end

CreateOrder.new(Shop.first)
```

#### Expected Result

- Initializer reises an error

#### Actual Result

- Initializer allows passing any ActiveRecord model, despite the specified class.

