### PR TITLE
Validate model to be instance of desired class

### DIFF
--- a/lib/dry/initializer/rails.rb
+++ b/lib/dry/initializer/rails.rb
@@ -9,6 +9,11 @@ rails_dispatcher = lambda do |model: nil, find_by: :id, **options|
   klass = model.is_a?(ActiveRecord::Relation) ? model.klass : model
 
   coercer = lambda do |value|
+    if value.is_a?(ActiveRecord::Base) && !value.instance_of?(klass)
+      fail ArgumentError
+        .new("Value `#{value.class}` is not instance of `#{klass}`")
+    end
+
     return value if value.nil? || value.is_a?(klass)
     model.find_by! find_by => value
   end

--- a/spec/dry/initializer/assignment_by_model_spec.rb
+++ b/spec/dry/initializer/assignment_by_model_spec.rb
@@ -8,13 +8,22 @@ describe "assignment by model" do
     end
   end
 
-  let!(:user) { User.create name: "Dude" }
-  let!(:item) { Item.create name: "The thing" }
+  let(:user) { User.create name: "Dude" }
+  let(:item) { Item.create name: "The thing" }
+
+  subject(:service) { Test::Order.new(user, product: item) }
 
   it "works" do
-    subject = Test::Order.new(user, product: item)
-
     expect(subject.user).to eql user
     expect(subject.product).to eql item
+  end
+
+  context "when option is not instance of class" do
+    let(:item) { User.create name: "NotAnItem" }
+
+    it "rejects" do
+      expect { service }
+        .to raise_error(ArgumentError, "Value `User` is not instance of `Item`")
+    end
   end
 end


### PR DESCRIPTION
Based off of https://github.com/nepalez/dry-initializer-rails/pull/2 (thanks @stgeneral for initial work)

## Description from initial PR https://github.com/nepalez/dry-initializer-rails/pull/2:

Initializer Rails allows passing any ActiveRecord model, despite the specified class.

I have some doubts that this is the best or "dry" way to handle this case, I just wanted to point out this issue with a possible solution.

#### Example
```ruby
class CreateOrder
  extend Dry::Initializer

  param :customer, model: Customer
end

CreateOrder.new(Shop.first)
```

#### Expected Result
* Initializer raises an error

#### Actual Result
* Initializer allows passing any ActiveRecord model, despite the specified class.

